### PR TITLE
Update _pslinux.py

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1298,7 +1298,7 @@ def disk_partitions(all=False):
 # =====================================================================
 
 
-def sensors_temperatures():
+def sensors_temperatures(force_thermalzone=False):
     """Return hardware (CPU and others) temperatures as a dict
     including hardware name, label, current, max and critical
     temperatures.
@@ -1366,7 +1366,7 @@ def sensors_temperatures():
         ret[unit_name].append((label, current, high, critical))
 
     # Indication that no sensors were detected in /sys/class/hwmon/
-    if not basenames:
+    if force_thermalzone or not basenames:
         basenames = glob.glob('/sys/class/thermal/thermal_zone*')
         basenames = sorted(set(basenames))
 


### PR DESCRIPTION
Add support for force thermal_zone info in sensors_temperatures().

## Summary

* OS: Linux armv7l 5.15.25
* Bug fix: yes
* Type: core
* Fixes: 1873

## Description

{{{
  Add an optional argument to `sensors_temperatures()`: `force_thermalzone` (default: `False`), if `True`, it will include temperatures from `/sys/class/thermal/thermal_zone*` even if there is temperatures from hwmon.
}}}
